### PR TITLE
Return chained image_tag to fix "size" attribute handling.

### DIFF
--- a/lib/retina_tag/engine.rb
+++ b/lib/retina_tag/engine.rb
@@ -27,13 +27,12 @@ module RetinaTag
       end
 
       options_default.merge!(options)
-      image_tag_without_retina(source,options_default)
 
       if options_default[:"data-lazy-load"]
         options_default["data-lowdpi-src"] = options_default.delete(:src)
       end
 
-      tag("img", options_default)
+      image_tag_without_retina(source, options_default)
     end
 
 


### PR DESCRIPTION
A call was originally being made to `image_tag_without_retina`, but the value was discarded and then it returned `tag("img")` which does not have the same effect. This changes the return to be the actual call to `image_tag_without_retina`. This has a side-effect of fixing https://github.com/davydotcom/retina_tag/issues/13 .

Tested, old output:

```
<img alt="..." class="..." src="..." size="21x21">
```

New output:

```
<img alt="..." class="..." src="..." width="21" height="21">
```

@davydotcom
