### PR TITLE
Fixing for sprockets 3 in production

### DIFF
--- a/lib/retina_tag/engine.rb
+++ b/lib/retina_tag/engine.rb
@@ -10,14 +10,20 @@ module RetinaTag
       src = options[:src] = path_to_image(source)
 
       begin
-          retina_els = source.split('.')
-          extension = retina_els.last
-          retina_els.slice!(-1)
-          retina_path = "#{retina_els.join('.')}@2x.#{extension}"
+        retina_els = source.split('.')
+        extension = retina_els.last
+        retina_els.slice!(-1)
+        retina_path = "#{retina_els.join('.')}@2x.#{extension}"
 
-          if retina_asset_present?(retina_path)
-            hidpi_asset_path = asset_path(retina_path)
-          end
+        retina_asset_present = if Rails.application.assets.present?
+          Rails.application.assets.find_asset(retina_path).present?
+        else
+          Rails.application.assets_manifest.files.values.any? { |asset| asset["logical_path"] == retina_path }
+        end
+
+        if retina_asset_present
+          hidpi_asset_path = asset_path(retina_path)
+        end
       rescue
       end
       options_default = { "data-hidpi-src" => hidpi_asset_path }
@@ -33,16 +39,6 @@ module RetinaTag
       end
 
       image_tag_without_retina(source, options_default)
-    end
-
-    def retina_asset_present?(path)
-      if Rails.application.assets.present?
-        Rails.application.assets.find_asset(path).present?
-      else
-        Rails.application.assets_manifest.files.values.any? do |asset|
-          asset["logical_path"] == path
-        end
-      end
     end
 
   end

--- a/lib/retina_tag/engine.rb
+++ b/lib/retina_tag/engine.rb
@@ -15,7 +15,7 @@ module RetinaTag
           retina_els.slice!(-1)
           retina_path = "#{retina_els.join('.')}@2x.#{extension}"
 
-          if !Rails.application.assets.find_asset(retina_path).nil?
+          if retina_asset_present?(retina_path)
             hidpi_asset_path = asset_path(retina_path)
           end
       rescue
@@ -35,6 +35,15 @@ module RetinaTag
       image_tag_without_retina(source, options_default)
     end
 
+    def retina_asset_present?(path)
+      if Rails.application.assets.present?
+        Rails.application.assets.find_asset(path).present?
+      else
+        Rails.application.assets_manifest.files.values.any? do |asset|
+          asset["logical_path"] == path
+        end
+      end
+    end
 
   end
 


### PR DESCRIPTION
Fixes https://github.com/davydotcom/retina_tag/issues/18

A recent sprockets update changed some internals, which prevented this gem from working in production

This sprockets-rails issue describes the actual error that caused this: rails/sprockets-rails#237
In production, Rails.application.assets is only set if config.assets.compile is enabled (and it's not enabled by default in production)

This fix worked for my. I'm not sure if it works as a global solution, but I supose it should

One thing still remains in the codebase which I did not fix: the whole problematic code is surrounded by a `begin/rescue`, which completely silences any errors within it, which made it harder to spot the problem in the first place, and will make it harder to see if it's working again

I'm not sure why it was originally put there, but I didn't remove it (although we probably should, it's a very big smell)