### PR TITLE
Remove a deprecated `alias_method_chain` call

### DIFF
--- a/lib/retina_tag/engine.rb
+++ b/lib/retina_tag/engine.rb
@@ -2,7 +2,10 @@
 module RetinaTag
   module TagHelper
     def self.included(base)
-      base.alias_method_chain :image_tag, :retina
+      base.module_eval do
+        alias_method :image_tag_without_retina, :image_tag
+        alias_method :image_tag, :image_tag_with_retina
+      end
     end
 
     def image_tag_with_retina(source,options={})

--- a/lib/retina_tag/engine.rb
+++ b/lib/retina_tag/engine.rb
@@ -1,4 +1,3 @@
-
 module RetinaTag
   module TagHelper
     def self.included(base)
@@ -8,7 +7,7 @@ module RetinaTag
       end
     end
 
-    def image_tag_with_retina(source,options={})
+    def image_tag_with_retina(source, options={})
       hidpi_asset_path = nil
       src = options[:src] = path_to_image(source)
 
@@ -21,7 +20,7 @@ module RetinaTag
         retina_asset_present = if Rails.application.assets.present?
           Rails.application.assets.find_asset(retina_path).present?
         else
-          Rails.application.assets_manifest.files.values.any? { |asset| asset["logical_path"] == retina_path }
+          Rails.application.assets_manifest.files.values.any? { |asset| asset['logical_path'] == retina_path }
         end
 
         if retina_asset_present
@@ -29,16 +28,16 @@ module RetinaTag
         end
       rescue
       end
-      options_default = { "data-hidpi-src" => hidpi_asset_path }
+      options_default = { 'data-hidpi-src' => hidpi_asset_path }
 
       if lazy = options.delete(:lazy)
-        options["data-lazy-load"] = lazy
+        options['data-lazy-load'] = lazy
       end
 
       options_default.merge!(options)
 
-      if options_default[:"data-lazy-load"]
-        options_default["data-lowdpi-src"] = options_default.delete(:src)
+      if options_default[:'data-lazy-load']
+        options_default['data-lowdpi-src'] = options_default.delete(:src)
       end
 
       image_tag_without_retina(source, options_default)
@@ -51,7 +50,6 @@ module RetinaTag
       ActionView::Helpers::AssetTagHelper.module_eval do
         include TagHelper
       end
-
     end
   end
 end


### PR DESCRIPTION
`alias_method_chain` has been deprecated in Rails 5, this PR is a workaround to remove the deprecation warning but leaving the behavior unchanged.