### PR TITLE
Add support for Turbolinks 5

### DIFF
--- a/app/assets/javascripts/retina_tag.js
+++ b/app/assets/javascripts/retina_tag.js
@@ -3,6 +3,7 @@ var RetinaTag = RetinaTag || {};
 RetinaTag.init = function() {
   window.matchMedia('(-webkit-device-pixel-ratio:1)').addListener(RetinaTag.updateImages);
   document.addEventListener("page:load", RetinaTag.updateImages);
+  document.addEventListener("turbolinks:load", RetinaTag.updateImages);
   document.addEventListener("retina_tag:refresh", RetinaTag.updateImages);
 };
 


### PR DESCRIPTION
Why:

* With Turbolinks 5 the event that's fired by Turbolinks when a page is
  loaded changed, therefore this gem does not support its latest
  version.

This change addresses the issue by:

* Refactoring the main script to add an event listener for the new event
  (`turbolinks:load`) on initialization.