### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,5 @@ If you set `:lazy => true` on an image_tag, the src attribute is moved to a data
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
 
-##License
+## License
 This project is licensed under the MIT License.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
